### PR TITLE
fix(governance): threshold boundary bug + tie detection

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1533,7 +1533,7 @@
         var leader = sorted[0];
         var runnerUp = sorted.length > 1 ? sorted[1] : 0;
         var margin = ((leader - runnerUp) / totalPool) * 100;
-        return { met: margin >= threshold, margin: margin };
+        return { met: margin > threshold, margin: margin };
       }
       function getTotalPool(voteMode) {
         if (voteMode === "all") return tokenTotalSupply || 0;
@@ -2045,10 +2045,14 @@
         var thresholdResult = checkThreshold(totals, totalPool, thresholdVal);
         var endsAt = new Date(p.ends_at);
         var isOpen = endsAt > new Date();
-        // Find winning choice index
+        // Find winning choice index — with tie detection
         var winnerIdx = 0;
-        totals.forEach(function (t, i) { if (t > totals[winnerIdx]) winnerIdx = i; });
-        return { choices: choices, votes: votes, totals: totals, grandTotal: grandTotal, totalPool: totalPool, thresholdVal: thresholdVal, thresholdResult: thresholdResult, endsAt: endsAt, isOpen: isOpen, winnerIdx: winnerIdx };
+        var tied = false;
+        totals.forEach(function (t, i) {
+          if (t > totals[winnerIdx]) { winnerIdx = i; tied = false; }
+          else if (i !== winnerIdx && t === totals[winnerIdx] && t > 0) { tied = true; }
+        });
+        return { choices: choices, votes: votes, totals: totals, grandTotal: grandTotal, totalPool: totalPool, thresholdVal: thresholdVal, thresholdResult: thresholdResult, endsAt: endsAt, isOpen: isOpen, winnerIdx: winnerIdx, tied: tied };
       }
 
       function renderProposalCards() {
@@ -2113,7 +2117,9 @@
           historyHead.style.display = "flex";
           closedList.forEach(function (item) {
             var p = item.p, t = item.t;
-            var statusBadge = t.thresholdResult.met
+            var statusBadge = t.tied
+              ? '<span class="badge badge-closed">Tied</span>'
+              : t.thresholdResult.met
               ? '<span class="badge badge-passed">Passed</span>'
               : '<span class="badge badge-closed">Closed</span>';
 


### PR DESCRIPTION
## Summary

Fixes 2 of the 3 governance bugs documented in #2:

- **Threshold boundary**: `checkThreshold()` used `>=` — a proposal with margin exactly equal to threshold would pass. Changed to `>` so margin must strictly exceed threshold.
- **Tie detection**: `tallyProposal()` silently declared the first choice as winner on ties. Now returns `{ tied: true }` when two or more choices share the highest vote count, and renders a "Tied" badge in proposal history.

Bug 3 (backend tally authority) is intentionally excluded — it requires an architecture decision (new `/api/proposals/:id/result` endpoint) and should be discussed separately.

## Changes

| Line | What | Before | After |
|---|---|---|---|
| 1536 | `checkThreshold()` | `margin >= threshold` | `margin > threshold` |
| 2048-2055 | `tallyProposal()` | Single-pass winner, no tie check | Tie-aware loop, `tied` flag in return |
| 2117-2121 | History rendering | Passed/Closed only | Tied/Passed/Closed |

## Test plan

- [ ] Create proposal with threshold=5%, get exactly 5% margin → should NOT pass (was passing before)
- [ ] Create proposal with 2 choices, equal votes → should show "Tied" badge (was showing winner before)
- [ ] Normal proposals (clear winner, margin > threshold) → unchanged behavior
- [ ] Zero-vote proposals → no false tie (guarded by `t > 0` check)

## Cross-references

- Fixes #2 (bugs 1 & 2)
- Related: PR #1 (infra fixes — CORS, tests, logging, rate limiting)
- ASDF-Web commits: `dc5dc1e`, `5ff6b54` (staking frontend alignment)

---
Generated with [Claude Code](https://claude.com/claude-code)